### PR TITLE
WIP: Add additional public bus timing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ before_script:
   - go get golang.org/x/lint/golint                        # Linter
   - go get github.com/fzipp/gocyclo
   - go get gopkg.in/telegram-bot-api.v4
-  - cd $GOPATH/src/github.com/usdevs
+  - cd $GOPATH && mkdir -p src/github.com/usdevs
+  - cd src/github.com/usdevs
   - git clone https://github.com/usdevs/cinnabot.git && cd cinnabot
   - go get ./...
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,12 @@ go_import_path: cinnabot
 # set -e enabled in bash. 
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/) # All the .go files, excluding vendor/
-  - go get github.com/golang/lint/golint                        # Linter
-  - go get honnef.co/go/tools/cmd/megacheck                     # Badass static analyzer/linter
+  - go get golang.org/x/lint/golint                        # Linter
   - go get github.com/fzipp/gocyclo
   - go get gopkg.in/telegram-bot-api.v4
-  - cd $GOPATH/
-  - git clone https://github.com/uschongensec/cinnabot.git
-  - cd cinnabot
-  - go get .
+  - cd $GOPATH/src/github.com/usdevs
+  - git clone https://github.com/usdevs/cinnabot.git && cd cinnabot
+  - go get ./...
 
 # script always run to completion (set +e). All of these code checks are must haves
 # in a modern Go project.
@@ -40,6 +38,5 @@ script:
   - test -z $(gofmt -s -l $GO_FILES)         # Fail if a .go file hasn't been formatted with gofmt
   - go test -v -race ./...                   # Run all the tests with the race detector enabled
   - go vet ./...                             # go vet is the official Go static analyzer
-  - megacheck ./...                          # "go vet on steroids" + linter
   - gocyclo -over 19 $GO_FILES               # forbid code with huge functions
   - golint -set_exit_status $(go list ./...) # one last linter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR will add a second bus timing to the display


## Description
<!--- Describe your changes in detail -->
problems:
- [ ] if a bus has no service, the bus service number is prepended with the word "bus" which is out of place
- [ ] there is a possibility that there is a first bus, but no subsequent ones. this case is not handled
- [ ] better still, write test cases

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently you can only see the eta for the next incoming public bus. Since the API provides 3 timings, we could use a second one :)
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Nope, we are yet to set up testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.