### PR TITLE
Laundry function

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Telegram Bot for Cinnamon College. [Telegram](https://t.me/cinnabot)
 - Show Singapore Public Bus Timings :oncoming_bus: `/publicbus`
 - Check facilities booking/events in Cinnamon College :school: `/spaces`
 - 2h Weather Forecast based on your location. :sunny: :umbrella: `/weather`
-
+- Lost? View maps of various parts of NUS :school: `/map`
+- Check laundry machine availability in Cinnamon College :shirt: `/laundry`
 
 Got a feature to suggest? :bulb:
 Bug to report? :bug:

--- a/basic.go
+++ b/basic.go
@@ -53,7 +53,6 @@ func (cb *Cinnabot) Start(msg *message) {
 // Help gives a list of handles that the user may call along with a description of them
 func (cb *Cinnabot) Help(msg *message) {
 	if len(msg.Args) > 0 {
-
 		if msg.Args[0] == "spaces" {
 			text :=
 				"To use the '/spaces' command, type one of the following:\n" +
@@ -85,7 +84,9 @@ func (cb *Cinnabot) Help(msg *message) {
 			"/resources: list of important resources!\n" +
 			"/spaces: list of space bookings\n" +
 			"/feedback: to give feedback\n" +
-			"/map: to get a map of NUS if you're lost!\n\n" +
+			"/map: to get a map of NUS if you're lost!\n" +
+			"/laundry: to check washer and dryer availability in cinnamon\n" +
+			"\n" +
 			"_*My creator actually snuck in a few more functions🕺 *_\n" +
 			"Try using /help <func name> to see what I can _really_ do"
 	cb.SendTextMessage(int(msg.Chat.ID), text)

--- a/firestore/query.go
+++ b/firestore/query.go
@@ -1,0 +1,226 @@
+// Package firestore reads from publically accessible Firestore databases using the REST API.
+//
+// The structs used largely mirror those used in the REST API.
+// types.go contains all the types supported by this library.
+package firestore
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+const (
+	// Operators
+	LessThan           = "LESS_THAN"
+	GreaterThan        = "GREATER_THAN"
+	LessThanOrEqual    = LessThan + orEqual
+	GreaterThanOrEqual = GreaterThan + orEqual
+	Equal              = "EQUAL"
+
+	orEqual = "_OR_EQUAL"
+
+	baseUrl         = "https://firestore.googleapis.com/v1beta1/"
+	nameFormat      = "projects/%s/databases/%s/documents" // first: project name, second: database name
+	defaultDatabase = "(default)"
+)
+
+type RawDocument struct {
+	Name string          `json:"name"`
+	Data json.RawMessage `json:"fields"`
+}
+
+type Document struct {
+	Name string      `json:"name"`
+	Data interface{} `json:"fields"`
+}
+
+// ParseData parses the raw JSON data in a RawDocument to any data type using the parse function, and returns
+// a Document containing the parsed data. A document containing the parsed data is returned even if the
+// parse function returns an error.
+func (raw RawDocument) ParseData(parse func(json.RawMessage) (interface{}, error)) (Document, error) {
+	data, err := parse(raw.Data)
+	if err != nil {
+		log.Printf("Error in firestore/query.go while parsing JSON: %s", err)
+	}
+	return Document{Name: raw.Name, Data: data}, err
+}
+
+type CollectionSelector struct {
+	CollectionId   string `json:"collectionId"`
+	AllDescendants bool   `json:"allDescendants"`
+}
+
+type fieldString string
+
+func (s fieldString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Val string `json:"fieldPath"`
+	}{string(s)})
+}
+
+// Filter represents a Firestore fieldFilter.
+type Filter struct {
+	Field          fieldString `json:"field"` // wrapper for string
+	Op             string      `json:"op"`
+	FirestoreValue interface{} `json:"value"` // one of the types defined in types.go
+}
+
+func (f Filter) MarshalJSON() ([]byte, error) {
+	type innerFilter Filter
+	return json.Marshal(struct {
+		Inner innerFilter `json:"fieldFilter"`
+	}{innerFilter(f)})
+}
+
+type Filters []Filter
+
+func (fils Filters) MarshalJSON() ([]byte, error) {
+	if fils == nil || len(fils) == 0 {
+		result, _ := json.Marshal(struct{}{})
+		return result, errors.New("Filters of a query with no filters should not be marshalled into JSON")
+	} else if len(fils) == 1 {
+		return json.Marshal(fils[0])
+	} else {
+		inner, err := json.Marshal(struct {
+			Op      string   `json:"op"`
+			Filters []Filter `json:"filters"`
+		}{"AND", fils})
+		if err != nil {
+			return make([]byte, 0), err
+		}
+		return json.Marshal(struct {
+			Inner json.RawMessage `json:"compositeFilter"`
+		}{inner})
+	}
+}
+
+type Query struct {
+	From  []CollectionSelector `json:"from"`
+	Where Filters              `json:"where"` // wrapper for []Filter
+}
+
+func (q Query) MarshalJSON() ([]byte, error) {
+	var inner json.RawMessage
+	var err error
+	if q.Where == nil || len(q.Where) == 0 {
+		type noFilter struct {
+			From []CollectionSelector `json:"from"`
+		}
+		inner, err = json.Marshal(noFilter{q.From})
+	} else {
+		type tmpQuery Query // avoid infinite recursion
+		inner, err = json.Marshal(tmpQuery(q))
+	}
+	if err != nil {
+		return make([]byte, 0), err
+	}
+	return json.Marshal(struct {
+		X json.RawMessage `json:"structuredQuery"`
+	}{inner})
+}
+
+func sendRequest(projectId string, query Query) ([]byte, error) {
+	url := baseUrl + fmt.Sprintf(nameFormat, projectId, defaultDatabase) + ":runQuery"
+	queryBytes, queryErr := json.Marshal(query)
+	if queryErr != nil {
+		log.Print("Error in firestore/query.go while constructing query")
+		return make([]byte, 0), queryErr
+	}
+
+	response, responseErr := http.Post(url, "application/json", bytes.NewReader(queryBytes))
+	if responseErr != nil {
+		log.Print("Error in firestore/query.go while receiving HTTP response")
+		return make([]byte, 0), responseErr
+	}
+	defer response.Body.Close()
+
+	rawData, rawDataErr := ioutil.ReadAll(response.Body)
+	if rawDataErr != nil {
+		log.Print("Error in firestore/query.go while reading HTTP response body")
+		return rawData, rawDataErr
+	}
+	return rawData, nil
+}
+
+// type strTime time.Time
+
+type queryDocument struct {
+	Document RawDocument `json:"document"`
+	// ReadTime strTime `json:"readTime"`
+}
+
+type errorResponse struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}
+
+// parseResponse returns an error if the response format cannot be parsed, or if the response describes an error.
+func parseResponse(body []byte) ([]RawDocument, error) {
+	docs := make([]RawDocument, 0)
+
+	var queryDocs []queryDocument
+	if jsonErr := json.Unmarshal(body, &queryDocs); jsonErr != nil {
+		log.Print("Error in firestore/query.go while parsing JSON")
+		return docs, jsonErr
+	}
+
+	for _, doc := range queryDocs {
+		docs = append(docs, doc.Document)
+	}
+
+	if len(docs) == 0 {
+		return docs, errors.New("Invalid response format")
+	}
+
+	// Check if there are actually Documents
+	if len(docs) == 1 && docs[0].Name == "" { // all firestore documents must have a name (path)
+		docs = make([]RawDocument, 0)
+
+		// Check for error response
+		var errorResp []errorResponse
+		json.Unmarshal(body, &errorResp)
+		if len(errorResp) > 0 && errorResp[0] != (errorResponse{}) {
+			log.Printf("Error response from firestore in firestore/query.go: %+v", errorResp[0])
+			return docs, errors.New(fmt.Sprintf("%+v", errorResp[0]))
+		}
+		// otherwise this means there are no matches, so just return an empty list and no error.
+	}
+
+	return docs, nil
+}
+
+// RunQuery queries the project with the specified ID and returns the response without parsing the document data.
+// An empty list of doucments is returned if any errors occur.
+func RunQuery(projectId string, query Query) ([]RawDocument, error) {
+	response, err := sendRequest(projectId, query)
+	if err != nil {
+		return make([]RawDocument, 0), err
+	}
+	return parseResponse(response)
+}
+
+// RunQueryAndParse queries the project with the specified ID and returns a response with the document data parsed
+// using the RawDocument.ParseData function. includeErrored is used to specify whether documents which cannot
+// be parsed using the parse function (ie. return an error) should be included in the returned list of documents.
+func RunQueryAndParse(projectId string, query Query, parse func(json.RawMessage) (interface{}, error), includeErrored bool) ([]Document, error) {
+	rawDocs, err := RunQuery(projectId, query)
+	docs := make([]Document, 0, len(rawDocs))
+	if err != nil {
+		return docs, err
+	}
+	for _, raw := range rawDocs {
+		doc, err := raw.ParseData(parse)
+		if includeErrored || err == nil {
+			docs = append(docs, doc)
+		}
+	}
+	return docs, nil
+}

--- a/firestore/query_test.go
+++ b/firestore/query_test.go
@@ -1,0 +1,132 @@
+package firestore
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/usdevs/cinnabot/utils"
+)
+
+func TestQuery(t *testing.T) {
+	// 1 filter
+	query := Query{
+		From:  []CollectionSelector{{"coll1", false}},
+		Where: []Filter{{Field: "abc", Op: GreaterThanOrEqual, FirestoreValue: Int(1)}},
+	}
+	result, err := json.Marshal(query)
+	if err != nil {
+		t.Error(err)
+	}
+	// t.Log(string(result))
+	expected := `{"structuredQuery":{"from":[{"collectionId":"coll1","allDescendants":false}],"where":{"fieldFilter":{"field":{"fieldPath":"abc"},"op":"GREATER_THAN_OR_EQUAL","value":{"integerValue":"1"}}}}}`
+	if string(result) != expected {
+		t.Errorf("Error in marshalling query, expected %s, got %s", expected, string(result))
+	}
+
+	// no filters
+	query = Query{
+		From:  []CollectionSelector{{"coll1", false}},
+		Where: make(Filters, 0),
+	}
+	result, err = json.Marshal(query)
+	if err != nil {
+		t.Error(err)
+	}
+	// t.Log(string(result))
+	expected = `{"structuredQuery":{"from":[{"collectionId":"coll1","allDescendants":false}]}}`
+	if string(result) != expected {
+		t.Errorf("Error in marshalling query with no filter, expected %s, got %s", expected, string(result))
+	}
+
+	// 2 filters
+	query = Query{
+		From:  []CollectionSelector{{"coll1", false}},
+		Where: []Filter{{Field: "abc", Op: GreaterThanOrEqual, FirestoreValue: Int(1)}, {Field: "xyz", Op: GreaterThanOrEqual, FirestoreValue: Int(2)}},
+	}
+	result, err = json.Marshal(query)
+	if err != nil {
+		t.Error(err)
+	}
+	// t.Log(string(result))
+	expected = `{"structuredQuery":{"from":[{"collectionId":"coll1","allDescendants":false}],"where":{"compositeFilter":{"op":"AND","filters":[{"fieldFilter":{"field":{"fieldPath":"abc"},"op":"GREATER_THAN_OR_EQUAL","value":{"integerValue":"1"}}},{"fieldFilter":{"field":{"fieldPath":"xyz"},"op":"GREATER_THAN_OR_EQUAL","value":{"integerValue":"2"}}}]}}}}`
+	if string(result) != expected {
+		t.Errorf("Error in marshalling query with multiple filters, expected %s, got %s", expected, string(result))
+	}
+}
+
+type testData struct {
+	PinNo       Int    `json:"pinNo"`
+	Name        String `json:"name"`
+	On          Bool   `json:"on"`
+	TimeChanged Time   `json:"timeChanged"` // use omitempty as needed
+}
+
+func (t testData) equal(other testData) bool {
+	return t.PinNo == other.PinNo && t.Name == other.Name && t.On == other.On && timeAndOffsetEqual(t.TimeChanged.Value(), other.TimeChanged.Value())
+}
+
+func TestDocument(t *testing.T) {
+	blob := `
+	[{"document": {
+		"name": "projects/usc-website-206715/databases/(default)/documents/events/FEHpJv0xavSNCEhqE7MS",
+		"fields": {
+			"pinNo": {"integerValue": "1" },
+			"on": {"booleanValue": true},
+			"name": {"stringValue": "A"},
+			"timeChanged": {"timestampValue": "2019-12-20T15:00:00Z"}
+		},
+		"createTime": "2018-11-08T09:54:34.250175Z",
+		"updateTime": "2018-11-08T09:54:34.250175Z"
+	},
+	"readTime": "2018-12-19T08:47:02.232588Z"}]`
+
+	loc, _ := time.LoadLocation("UTC")
+	expected := testData{1, "A", true, Time(time.Date(2019, time.December, 20, 15, 0, 0, 0, loc).In(utils.SgLocation()))}
+
+	rawdocs, err := parseResponse([]byte(blob))
+	if err != nil {
+		t.Errorf("Error in parseRespones: %s", err)
+	}
+	t.Log(string(rawdocs[0].Data))
+	parse := func(data json.RawMessage) (interface{}, error) {
+		obj := testData{}
+		err := json.Unmarshal(data, &obj)
+		return obj, err
+	}
+	doc, err := rawdocs[0].ParseData(parse)
+	if err != nil {
+		t.Errorf("Error in parsing raw document: %s", err)
+	}
+	t.Logf("%+v", doc)
+	if !expected.equal(doc.Data.(testData)) {
+		t.Errorf("Parsed data is incorrect, expected %+v, got %+v", expected, doc.Data)
+	}
+	// Verify that type conversion works
+	// typed := doc.Data.(testData)
+	// t.Log(typed)
+}
+
+// func TestSendQuery(t *testing.T) {
+// 	query := Query{
+// 		From:  []CollectionSelector{CollectionSelector{"laundry_status", false}},
+// 		Where: []Filter{Filter{Field: "abc", Op: Equal, FirestoreValue: Int(1)}, Filter{Field: "xyz", Op: GreaterThanOrEqual, FirestoreValue: Int(2)}},
+// 	}
+
+// 	docs, err := RunQuery("usc-laundry-test", query)
+// 	t.Logf("%+v", docs)
+// 	t.Log(err)
+
+// 	// 	resp, err := sendRequest("usc-laundry-test", query)
+// 	// 	t.Log(string(resp))
+// 	// 	// no error returned if not found/invalid query. Only error if invliad URL/offline.
+// 	// 	// [{"readTime": "2019-12-23T04:31:05.621387Z"}] returned if no matches
+
+// 	// 	if err != nil || resp == nil || len(resp) == 0 {
+// 	// 		t.Error(err)
+// 	// 	}
+
+// 	// 	docs, parseErr := parseResponse(resp)
+// 	// 	t.Logf("%+v", docs)
+// 	// 	t.Log(parseErr)
+// }

--- a/firestore/types.go
+++ b/firestore/types.go
@@ -1,0 +1,110 @@
+package firestore
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/usdevs/cinnabot/utils"
+)
+
+// String is a wrapper for a string in firestore, which has the JSON format {"stringValue": "abc"}.
+type String string
+
+// Time is a wrapper for a timestamp in firestore, which has the JSON format { "timestampValue": "yyyy-mm-ddThh:mm:ssZ" }.
+type Time time.Time
+
+// Int is a wrapper for an integer in firestore, which has the JSON format {"integerValue": "1"}.
+type Int int
+
+// Bool is a wrapper for a boolean in firestore, which has the JSON format {"booleanValue" : true}.
+type Bool bool
+
+type rawString struct {
+	Val string `json:"stringValue"`
+}
+
+type rawTime struct {
+	Val string `json:"timestampValue"`
+}
+
+type rawInt struct {
+	Val string `json:"integerValue"`
+}
+
+type rawBool struct {
+	Val bool `json:"booleanValue"`
+}
+
+// JSON Unmarshaller implementation
+
+func (fs *String) UnmarshalJSON(data []byte) error {
+	var raw rawString
+	jsonErr := json.Unmarshal(data, &raw)
+	*fs = String(raw.Val)
+	return jsonErr
+}
+
+func (ft *Time) UnmarshalJSON(data []byte) error {
+	var raw rawTime
+	if jsonErr := json.Unmarshal(data, &raw); jsonErr != nil {
+		return jsonErr
+	}
+	time, timeErr := time.Parse("2006-01-02T15:04:05Z", raw.Val)
+	*ft = Time(time.In(utils.SgLocation())) // convert to Sg time for display purposes
+	return timeErr
+}
+
+func (fi *Int) UnmarshalJSON(data []byte) error {
+	var raw rawInt
+	if jsonErr := json.Unmarshal(data, &raw); jsonErr != nil {
+		return jsonErr
+	}
+	i, err := strconv.Atoi(raw.Val)
+	if err != nil {
+		return err
+	}
+	*fi = Int(i)
+	return nil
+}
+
+func (fb *Bool) UnmarshalJSON(data []byte) error {
+	var raw rawBool
+	jsonErr := json.Unmarshal(data, &raw)
+	*fb = Bool(raw.Val)
+	return jsonErr
+}
+
+// JSON Marshaller implementation
+
+func (fs String) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rawString{string(fs)})
+}
+
+func (ft Time) MarshalJSON() ([]byte, error) {
+	timeString := time.Time(ft).UTC().Format("2006-01-02T15:04:05Z")
+	return json.Marshal(rawTime{timeString})
+}
+
+func (fi Int) MarshalJSON() ([]byte, error) {
+	str := strconv.Itoa(int(fi))
+	return json.Marshal(rawInt{str})
+}
+
+func (fb Bool) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rawBool{bool(fb)})
+}
+
+// Getters
+
+func (fs String) Value() string { return string(fs) }
+
+func (ft Time) Value() time.Time { return time.Time(ft) }
+
+func (fb Bool) Value() bool { return bool(fb) }
+
+func (fi Int) Value() int { return int(fi) }
+
+// fmt.Stringer is implemented to allow pretty printing
+
+func (ft Time) String() string { return ft.Value().String() }

--- a/firestore/types_test.go
+++ b/firestore/types_test.go
@@ -1,0 +1,113 @@
+package firestore
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/usdevs/cinnabot/utils"
+)
+
+func TestString(t *testing.T) {
+	blob := `{"stringValue":"abc"}`
+	var value String
+
+	// Unmarshalling
+	if err := json.Unmarshal([]byte(blob), &value); err != nil {
+		t.Errorf("JSON unmarshalling error: %s", err)
+	}
+	expected := "abc"
+	if value.Value() != expected {
+		t.Errorf("%T unmarshalling: %v expected, got %v", expected, expected, value.Value())
+	}
+
+	// Marshalling
+	tmp, err := json.Marshal(value)
+	if err != nil {
+		t.Errorf("JSON marshalling error: %s", err)
+	}
+	result := string(tmp)
+	if result != blob {
+		t.Errorf("%T marshalling: %v expected, got %v", expected, blob, result)
+	}
+}
+
+func TestInt(t *testing.T) {
+	blob := `{"integerValue":"1"}`
+	var value Int
+
+	// Unmarshalling
+	if err := json.Unmarshal([]byte(blob), &value); err != nil {
+		t.Errorf("JSON unmarshalling error: %s", err)
+	}
+	expected := 1
+	if value.Value() != expected {
+		t.Errorf("%T unmarshalling: %v expected, got %v", expected, expected, value.Value())
+	}
+
+	// Marshalling
+	tmp, err := json.Marshal(value)
+	if err != nil {
+		t.Errorf("JSON marshalling error: %s", err)
+	}
+	result := string(tmp)
+	if result != blob {
+		t.Errorf("%T marshalling: %v expected, got %v", expected, blob, result)
+	}
+}
+
+// timeAndOffsetEqual checks if 2 times have the same value and timezone.
+func timeAndOffsetEqual(t1, t2 time.Time) bool {
+	timeEq := t1.Equal(t2)
+	_, offset1 := t1.Zone()
+	_, offset2 := t2.Zone()
+	locEq := offset1 == offset2
+	return timeEq && locEq
+}
+
+func TestTime(t *testing.T) {
+	blob := `{"timestampValue":"2019-12-20T13:00:00Z"}`
+
+	// Unmarshalling
+	var value Time
+	if err := json.Unmarshal([]byte(blob), &value); err != nil {
+		t.Errorf("JSON unmarshalling error: %s", err)
+	}
+	loc, _ := time.LoadLocation("UTC")
+	expected := time.Date(2019, time.December, 20, 13, 0, 0, 0, loc).In(utils.SgLocation())
+	if !timeAndOffsetEqual(expected, value.Value()) {
+		t.Errorf("%T %v expected, got %v", expected, expected, value.Value())
+	}
+
+	// Marshalling
+	tmp, err := json.Marshal(value)
+	if err != nil {
+		t.Errorf("JSON marshalling error: %s", err)
+	}
+	result := string(tmp)
+	if result != blob {
+		t.Errorf("%T marshalling: %v expected, got %v", expected, blob, result)
+	}
+}
+
+func TestBool(t *testing.T) {
+	blob := `{"booleanValue":false}`
+	var value Bool
+	if err := json.Unmarshal([]byte(blob), &value); err != nil {
+		t.Errorf("JSON unmarshalling error: %s", err)
+	}
+	expected := false
+	if value.Value() != expected {
+		t.Errorf("%T %v expected, got %v", expected, expected, value.Value())
+	}
+
+	// Marshalling
+	tmp, err := json.Marshal(value)
+	if err != nil {
+		t.Errorf("JSON marshalling error: %s", err)
+	}
+	result := string(tmp)
+	if result != blob {
+		t.Errorf("%T marshalling: %v expected, got %v", expected, blob, result)
+	}
+}

--- a/laundry.go
+++ b/laundry.go
@@ -1,0 +1,450 @@
+package cinnabot
+
+import (
+	"encoding/json"
+	"fmt"
+	tgbotapi "gopkg.in/telegram-bot-api.v4"
+	"log"
+	"sort"
+	"strings"
+	"time"
+
+	fs "github.com/usdevs/cinnabot/firestore"
+	"github.com/usdevs/cinnabot/utils"
+)
+
+// Backend
+
+const projectId = "usc-laundry-test"
+
+// Firestore document structs
+type machineData struct {
+	PinNo              fs.Int    `json:"pinNo"`
+	Name               fs.String `json:"name"`
+	Ezlink             fs.Bool   `json:"ezlink"`
+	Washer             fs.Bool   `json:"washer"`
+	On                 fs.Bool   `json:"on"`
+	TimeChanged        fs.Time   `json:"timeChanged"`
+	TimeChangedCertain fs.Bool   `json:"timeChangedCertain"`
+	Cinnabot           fs.Bool   `json:"cinnabot"`
+	Pi                 fs.Int    `json:"piNo"`
+}
+
+type piData struct {
+	PiNo     fs.Int  `json:"piNo"`
+	Level    fs.Int  `json:"level"`
+	LastSeen fs.Time `json:"lastSeen"`
+}
+
+func firestoreToMachine(machineD machineData, pi piData) machine {
+	return machine{
+		Name:               machineD.Name.Value(),
+		Ezlink:             machineD.Ezlink.Value(),
+		Washer:             machineD.Washer.Value(),
+		On:                 machineD.On.Value(),
+		TimeChanged:        machineD.TimeChanged.Value(),
+		TimeChangedCertain: machineD.TimeChangedCertain.Value(),
+		Level:              pi.Level.Value(),
+		LastSeen:           pi.LastSeen.Value(),
+	}
+}
+
+func machineQuery() fs.Query {
+	return fs.Query{
+		From: []fs.CollectionSelector{{
+			CollectionId:   "laundry_status",
+			AllDescendants: false,
+		}},
+		Where: make(fs.Filters, 0),
+	}
+}
+
+func getPiData() (map[int]piData, error) {
+	query := fs.Query{
+		From: []fs.CollectionSelector{{
+			CollectionId:   "pi_status",
+			AllDescendants: false,
+		}},
+		Where: make(fs.Filters, 0),
+	}
+	parse := func(data json.RawMessage) (interface{}, error) {
+		obj := piData{}
+		err := json.Unmarshal(data, &obj)
+		return obj, err
+	}
+	piDocs, err := fs.RunQueryAndParse(projectId, query, parse, false)
+
+	piMap := make(map[int]piData, len(piDocs))
+	if err != nil {
+		log.Print("Error getting pi data from firestore:", err)
+		return piMap, err
+	}
+	for _, doc := range piDocs {
+		data := doc.Data.(piData)
+		piMap[data.PiNo.Value()] = data
+	}
+	return piMap, nil
+}
+
+func getMachineData(query fs.Query) ([]machineData, error) {
+	parse := func(data json.RawMessage) (interface{}, error) {
+		obj := machineData{}
+		err := json.Unmarshal(data, &obj)
+		return obj, err
+	}
+	machineDocs, err := fs.RunQueryAndParse(projectId, query, parse, false)
+
+	machines := make([]machineData, 0, len(machineDocs))
+	if err != nil {
+		log.Print("Error getting laundry machine data from firestore:", err)
+		return machines, err
+	}
+	for _, doc := range machineDocs {
+		machines = append(machines, doc.Data.(machineData))
+	}
+	return machines, nil
+}
+
+func toMachines(mData []machineData, piMap map[int]piData) []machine {
+	machines := make([]machine, 0, 18)
+	for _, md := range mData {
+		if pi, ok := piMap[md.Pi.Value()]; ok {
+			machines = append(machines, firestoreToMachine(md, pi))
+		} else {
+			log.Printf("toMachines function in laundry.go: pi %d, which is connected to machine %s, cannot be found in firestore", md.Pi, md.Name)
+			// log.Printf("Machine %s is connected to pi %d which cannot be found in firestore", md.Name.Value(), md.Pi.Value())
+		}
+	}
+	return machines
+}
+
+// splitByLevel returns the machines in level 9/level 17 respectively
+func splitByLevel(machines []machine) ([]machine, []machine) {
+	l9 := make([]machine, 0)
+	l17 := make([]machine, 0)
+	for _, m := range machines {
+		if m.Level == 9 {
+			l9 = append(l9, m)
+		} else if m.Level == 17 {
+			l17 = append(l17, m)
+		} else {
+			log.Printf("Washing machine with invalid level (level %d, name %s)", m.Level, m.Name)
+		}
+	}
+	return l9, l17
+}
+
+func splitByType(machines []machine) ([]washer, []dryer) {
+	washers := make([]washer, 0)
+	dryers := make([]dryer, 0)
+	for _, m := range machines {
+		if m.Washer {
+			washers = append(washers, washer(m))
+		} else {
+			dryers = append(dryers, dryer(m))
+		}
+	}
+	return washers, dryers
+}
+
+// used by UI
+
+func getAllMachines() ([]level, error) {
+	levels := make([]level, 0, 2)
+	piData, piErr := getPiData()
+	if piErr != nil {
+		return levels, piErr
+	}
+	mData, mErr := getMachineData(machineQuery())
+	if mErr != nil {
+		return levels, mErr
+	}
+	machines := toMachines(mData, piData)
+	l9, l17 := splitByLevel(machines)
+	for i, m := range [2][]machine{l9, l17} {
+		var lastSeen time.Time
+		if len(m) > 0 { // if there are no machines on a level it won't be printed
+			lastSeen = m[0].LastSeen
+		}
+		washers, dryers := splitByType(m)
+		var l int
+		if i == 0 {
+			l = 9
+		} else {
+			l = 17
+		}
+		levels = append(levels, level{l, washers, dryers, lastSeen})
+	}
+	return levels, nil
+}
+
+// func getMachineType(isWasher bool) []level {
+// 	// not the most efficient solution but there are only 18 washers + dryers
+// 	levels := getAllMachines()
+// 	for _, l := range levels {
+// 		if isWasher {
+// 			l.dryers = make([]dryer, 0)
+// 		} else {
+// 			l.washers = make([]washer, 0)
+// 		}
+// 	}
+// 	return levels
+// }
+
+// func getLevel(lvl int) []level {
+// 	levels := make([]level, 0, 1)
+// 	if lvl != 9 && lvl != 17 {
+// 		log.Printf("Invalid level used in getLevel function in laundry.go: there's no laundry room on level %d", lvl)
+// 		return levels
+// 	}
+
+// 	piData, piErr := getPiData()
+// 	if piErr != nil {
+// 		return levels
+// 	}
+// 	mData, mErr := getMachineData(machineQuery())
+// 	if mErr != nil {
+// 		return levels
+// 	}
+// 	machines := toMachines(mData, piData)
+// 	l9, l17 := splitByLevel(machines)
+// 	if lvl == 9 {
+// 		machines = l9
+// 	} else if lvl == 17 {
+// 		machines = l17
+// 	}
+// 	washers, dryers := splitByType(machines)
+// 	levels = append(levels, level{lvl, washers, dryers})
+// 	return levels
+// }
+
+// UI
+
+const (
+	washerCycle      = time.Duration(time.Minute * 30)
+	dryerSingleCycle = time.Duration(time.Minute * 45)
+	dryerDoubleCycle = dryerSingleCycle * 2
+
+	notWorkingStr = " (sensor may not be working)"
+	notCertainStr = " (or less)"
+)
+
+func formatTimeLeft(timeLeft time.Duration) string {
+	if timeLeft < 0 {
+		timeLeft = 0
+	}
+	return fmt.Sprintf("%d mins left", int(timeLeft.Minutes()))
+}
+
+func seenRecently(lastSeen time.Time) bool {
+	return time.Since(lastSeen) < time.Duration(time.Minute*10)
+}
+
+type machine struct {
+	Name               string
+	Level              int
+	Ezlink             bool
+	Washer             bool
+	On                 bool
+	TimeChanged        time.Time
+	TimeChangedCertain bool
+	LastSeen           time.Time
+}
+
+func (m machine) timeLeft(cycleLength time.Duration) time.Duration {
+	return cycleLength - time.Since(m.TimeChanged)
+}
+
+func (m machine) description() string {
+	var ezlinkStr string
+	if m.Ezlink {
+		ezlinkStr = "ezlink"
+	} else {
+		ezlinkStr = "coin"
+	}
+	return fmt.Sprintf("*%s (%s)*", m.Name, ezlinkStr)
+}
+
+type washer machine
+
+func (w washer) timeLeft() time.Duration {
+	return machine(w).timeLeft(washerCycle)
+}
+
+func (w washer) string() string {
+	str := machine(w).description() + ": "
+	if w.On {
+		// not free
+		timeLeft := w.timeLeft()
+		str += formatTimeLeft(timeLeft)
+		if timeLeft.Minutes() < -5 {
+			str += notWorkingStr
+		} else if !w.TimeChangedCertain {
+			str += notCertainStr
+		}
+	} else {
+		str += "free"
+	}
+	return str
+	// treats the last seen time of each sensor individually
+	// str := machine(w).description() + ": "
+	// sensorWorking := seenRecently(w.LastSeen)
+	// if w.On {
+	// 	// not free
+	// 	timeLeft := w.timeLeft()
+	// 	str += formatTimeLeft(timeLeft)
+	// 	if timeLeft < 0 && !sensorWorking || timeLeft.Minutes() < -5 {
+	// 		str += notWorkingStr
+	// 	} else if !w.TimeChangedCertain {
+	// 		str += notCertainStr
+	// 	}
+	// } else {
+	// 	str += "free"
+	// 	if !sensorWorking {
+	// 		str += notWorkingStr
+	// 	}
+	// }
+	// return str
+}
+
+type dryer machine
+
+func (d dryer) timeLeft() (time.Duration, time.Duration) {
+	m := machine(d)
+	return m.timeLeft(dryerSingleCycle), m.timeLeft(dryerDoubleCycle)
+}
+
+func (d dryer) string() string {
+	str := machine(d).description() + ": "
+	// sensorWorking := seenRecently(d.LastSeen)
+	if d.On {
+		// not free
+		single, double := d.timeLeft()
+		if single.Minutes() >= -2 { // 2 mins buffer
+			str += formatTimeLeft(single) + " (single tap) / "
+		}
+		str += formatTimeLeft(double) + " (double tap)"
+		if double.Minutes() < -5 { // single < 0 && !sensorWorking || double.Minutes() < -5 {
+			str += notWorkingStr
+		} else if !d.TimeChangedCertain {
+			str += notCertainStr
+		}
+	} else {
+		// free
+		str += "free"
+		// 	if !sensorWorking {
+		// 		str += notWorkingStr
+		// 	}
+	}
+	return str
+}
+
+// sorting
+
+func genericLess(first, second machine) bool {
+	if first.Name == second.Name {
+		return first.Ezlink
+	} else {
+		return first.Name < second.Name
+	}
+}
+
+func sortWashers(washers []washer) {
+	less := func(i, j int) bool {
+		return genericLess(machine(washers[i]), machine(washers[j]))
+	}
+	sort.Slice(washers, less)
+}
+
+func sortDryers(dryers []dryer) {
+	less := func(i, j int) bool {
+		return genericLess(machine(dryers[i]), machine(dryers[j]))
+	}
+	sort.Slice(dryers, less)
+}
+
+type level struct {
+	lvl     int
+	washers []washer
+	dryers  []dryer
+	// assumption: 1 RPi per floor
+	piLastSeen time.Time
+}
+
+func (l level) Len() int {
+	return len(l.washers) + len(l.dryers)
+}
+
+func (l level) string() string {
+	sortWashers(l.washers)
+	sortDryers(l.dryers)
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("*LEVEL %d*\n", l.lvl))
+
+	if !seenRecently(l.piLastSeen) {
+		txt := "\u2757 Probably not accurate, the sensors were last seen at " + l.piLastSeen.Format(time.RFC822) + ".\n"
+		sb.WriteString(txt)
+	}
+
+	if len(l.washers) > 0 {
+		sb.WriteString("====== *Washers* ======")
+		for _, m := range l.washers {
+			sb.WriteString("\n")
+			sb.WriteString(m.string())
+		}
+		sb.WriteString("\n")
+	}
+	if len(l.dryers) > 0 {
+		sb.WriteString("======= *Dryers* =======")
+		for _, m := range l.dryers {
+			sb.WriteString("\n")
+			sb.WriteString(m.string())
+		}
+	}
+	return sb.String()
+}
+
+func laundryMsg() string {
+	lastUpdated := "Last updated: " + time.Now().In(utils.SgLocation()).Format(time.RFC822)
+	levels, err := getAllMachines()
+
+	if err != nil {
+		return "Could not fetch laundry availability.\n" + lastUpdated
+	}
+
+	toSend := ""
+	for _, l := range levels {
+		if l.Len() > 0 {
+			toSend += l.string()
+			toSend += "\n\n"
+		}
+	}
+
+	return toSend + lastUpdated
+}
+
+func makeLaundryRefreshButton() tgbotapi.InlineKeyboardMarkup {
+	return tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Refresh", "//laundry_refresh")),
+	)
+}
+
+func (cb *Cinnabot) LaundryRefresh(qry *callback) {
+	text := laundryMsg()
+	refreshButton := makeLaundryRefreshButton()
+	msg := tgbotapi.NewEditMessageText(qry.ChatID, qry.MsgID, text)
+	msg.ParseMode = tgbotapi.ModeMarkdown
+	msg.ReplyMarkup = &refreshButton
+	cb.SendMessage(msg)
+}
+
+// Laundry checks the washer and dryer availability.
+func (cb *Cinnabot) Laundry(msg *message) {
+	text := laundryMsg()
+	refreshButton := makeLaundryRefreshButton()
+	newMsg := tgbotapi.NewMessage(msg.Chat.ID, text)
+	newMsg.ParseMode = tgbotapi.ModeMarkdown
+	newMsg.ReplyMarkup = &refreshButton
+	cb.SendMessage(newMsg)
+}

--- a/laundry_test.go
+++ b/laundry_test.go
@@ -1,0 +1,125 @@
+package cinnabot
+
+import (
+	"testing"
+	"time"
+)
+
+type printable interface {
+	string() string
+}
+
+// Just prints output format when using -v flag. Doesn't actually test anything.
+func TestStrings(t *testing.T) {
+
+	// washer off
+	w1 := washer{
+		Name:               "A",
+		Level:              17,
+		Ezlink:             false,
+		Washer:             true,
+		On:                 false,
+		TimeChanged:        time.Now().Add(time.Duration(time.Minute * -10)),
+		TimeChangedCertain: true,
+		LastSeen:           time.Now().Add(time.Duration(time.Minute * -2)),
+	}
+
+	// washer on, < 30 min
+	w2 := washer{
+		Name:               "A",
+		Level:              17,
+		Ezlink:             false,
+		Washer:             true,
+		On:                 true,
+		TimeChanged:        time.Now().Add(time.Duration(time.Minute * -20)),
+		TimeChangedCertain: true,
+		LastSeen:           time.Now().Add(time.Duration(time.Minute * -2)),
+	}
+
+	// washer off, hasn't been seen in a while
+	w3 := washer{
+		Name:               "A",
+		Level:              17,
+		Ezlink:             false,
+		Washer:             true,
+		On:                 false,
+		TimeChanged:        time.Now().Add(time.Duration(time.Minute * -10)),
+		TimeChangedCertain: true,
+		LastSeen:           time.Now().Add(time.Duration(time.Minute * -20)),
+	}
+
+	// washer on, uncertain start time
+	w4 := washer{
+		Name:               "A",
+		Level:              17,
+		Ezlink:             false,
+		Washer:             true,
+		On:                 true,
+		TimeChanged:        time.Now().Add(time.Duration(time.Minute * -10)),
+		TimeChangedCertain: false,
+		LastSeen:           time.Now().Add(time.Duration(time.Minute * -2)),
+	}
+
+	// washer on, overran slightly (and uncertain start time)
+	w5 := washer{
+		Name:               "A",
+		Level:              17,
+		Ezlink:             false,
+		Washer:             true,
+		On:                 true,
+		TimeChanged:        time.Now().Add(time.Duration(time.Minute * -32)),
+		TimeChangedCertain: false,
+		LastSeen:           time.Now().Add(time.Duration(time.Minute * -2)),
+	}
+
+	// washer on, overran alot (likely broken sensor)
+	w6 := washer{
+		Name:               "A",
+		Level:              17,
+		Ezlink:             false,
+		Washer:             true,
+		On:                 true,
+		TimeChanged:        time.Now().Add(time.Duration(time.Minute * -39)),
+		TimeChangedCertain: true,
+		LastSeen:           time.Now().Add(time.Duration(time.Minute * -2)),
+	}
+
+	d1 := dryer{
+		Name:               "A",
+		Level:              17,
+		Ezlink:             false,
+		Washer:             false,
+		On:                 false,
+		TimeChanged:        time.Now().Add(time.Duration(time.Minute * -39)),
+		TimeChangedCertain: true,
+		LastSeen:           time.Now().Add(time.Duration(time.Minute * -2)),
+	}
+
+	d2 := dryer{
+		Name:               "A",
+		Level:              17,
+		Ezlink:             false,
+		Washer:             false,
+		On:                 true,
+		TimeChanged:        time.Now().Add(time.Duration(time.Minute * -20)),
+		TimeChangedCertain: true,
+		LastSeen:           time.Now().Add(time.Duration(time.Minute * -2)),
+	}
+
+	d3 := dryer{
+		Name:               "A",
+		Level:              17,
+		Ezlink:             false,
+		Washer:             false,
+		On:                 true,
+		TimeChanged:        time.Now().Add(time.Duration(time.Minute * -50)),
+		TimeChangedCertain: true,
+		LastSeen:           time.Now().Add(time.Duration(time.Minute * -2)),
+	}
+
+	machines := []printable{w1, w2, w3, w4, w5, w6, d1, d2, d3}
+	for i, m := range machines {
+		t.Log(i + 1)
+		t.Log(m.string())
+	}
+}

--- a/main/main.go
+++ b/main/main.go
@@ -38,8 +38,8 @@ func main() {
 	cb.AddFunction("/nusbus", cb.NUSBus)
 	cb.AddFunction("/weather", cb.Weather)
 	cb.AddFunction("/map", cb.NUSMap)
-
 	cb.AddFunction("/spaces", cb.Spaces)
+	cb.AddFunction("/laundry", cb.Laundry)
 
 	cb.AddFunction("/feedback", cb.Feedback)
 	cb.AddFunction("/dhsurvey", cb.DHSurvey)
@@ -53,6 +53,7 @@ func main() {
 
 	// Callback handlers
 	cb.AddHandler("//nusbus_refresh", cb.NUSBusResfresh)
+	cb.AddHandler("//laundry_refresh", cb.LaundryRefresh)
 
 	updates := cb.Listen(60)
 	log.Println("Listening...")

--- a/spaces.go
+++ b/spaces.go
@@ -3,130 +3,35 @@ package cinnabot
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"net/http"
 	"sort"
 	"strings"
 	"time"
+
+	fs "github.com/usdevs/cinnabot/firestore"
 )
 
-// for firestore queries (use with makeQuery)
+// Displaying:
 
-// GreaterThan is the > operator
-const GreaterThan = "GREATER_THAN"
+// FormatDate formats a time.Time into date in a standardised format
+func FormatDate(t time.Time) string {
+	return t.Local().Format("Mon 02 Jan 06")
+}
 
-// PARSING AND QUERYING:
-
-// makeQuery returns a string to be used as the request body of a firestore query
-// jsonValue must be either a jsonTime or jsonString
-// see https://developers.google.com/apis-explorer/#search/firestore/firestore/v1beta1/firestore.projects.databases.documents.runQuery and https://cloud.google.com/firestore/docs/query-data/queries for details
-func makeQuery(fieldName string, op string, jsonValue interface{}) string {
-	formatString := `
-	{
-	"structuredQuery": {
-		"where": {
-			"fieldFilter": {
-				"field": { "fieldPath": "%s" },
-				"op": "%s" ,
-				"value": %s
-			}
-		},
-		"from": [ {"collectionId": "events"} ]
+// FormatTime formats a time.Time into a time in a standardised format
+func FormatTime(t time.Time) string {
+	localT := t.Local()
+	if localT.Minute() == 0 {
+		return localT.Format("03PM")
 	}
-	}
-	`
-
-	valueAsJSON, _ := json.Marshal(jsonValue)
-	return fmt.Sprintf(formatString, fieldName, op, string(valueAsJSON))
+	return localT.Format("03:04PM")
 }
 
-// A query will return a list of objects like the one below (some fields omitted for berevity).
-// See https://developers.google.com/apis-explorer/#search/firestore/firestore/v1beta1/firestore.projects.databases.documents.runQuery
-/*
-{"document": {
-    "name": "projects/usc-website-206715/databases/(default)/documents/events/FEHpJv0xavSNCEhqE7MS",
-    "fields": {
-      "name": {"stringValue": "Mass Check-In"},
-      "venueName": {"stringValue": "Chatterbox" },
-      "fullDay": {"booleanValue": true },
-      "venue": {"stringValue": "V4TTAgG9fe4bjSm4Vl3M"},
-      "endDate": {"timestampValue": "2019-01-16T15:30:00Z"},
-      "startDate": {"timestampValue": "2019-01-15T16:00:00Z"}
-    },
-    "createTime": "2018-11-08T09:54:34.250175Z",
-    "updateTime": "2018-11-08T09:54:34.250175Z"
-  },
-  "readTime": "2018-12-19T08:47:02.232588Z"}
-*/
-
-// jsonString is a wrapper for string values returned by firestore/used in firestore queries which use the format {"stringValue" : "acutal string"}
-type jsonString string
-
-// jsonTime is a wrapper for timestamps returned from firestore/ used in firestore queries which use the format {"timestampValue": yyyy-mm-ddThh:mm:ssZ}
-type jsonTime time.Time
-
-type rawEventFields struct {
-	Name  jsonString `json:"name"`
-	Venue jsonString `json:"venueName"`
-	Start jsonTime   `json:"startDate"`
-	End   jsonTime   `json:"endDate"`
+// FormatTimeDate formats a time.Time into a full time and date, in a standardised format
+func FormatTimeDate(t time.Time) string {
+	return fmt.Sprintf("%s, %s", FormatTime(t), FormatDate(t))
 }
-
-type rawEvent struct {
-	Fields rawEventFields `json:"fields"`
-}
-
-// queryDocument represents 1 firestore document (for 1 event). A query returns []eventsQueryDocument
-type queryDocument struct {
-	RawEvent rawEvent `json:"document"`
-}
-
-func (js *jsonString) UnmarshalJSON(data []byte) error {
-	var rawString struct {
-		Val string `json:"stringValue"`
-	}
-
-	jsonErr := json.Unmarshal(data, &rawString)
-	*js = jsonString(rawString.Val)
-	return jsonErr
-}
-
-func (js jsonString) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		Val string `json:"stringValue"`
-	}{string(js)})
-}
-
-func (jt *jsonTime) UnmarshalJSON(data []byte) error {
-	var rawString struct {
-		Val string `json:"timestampValue"`
-	}
-	if jsonErr := json.Unmarshal(data, &rawString); jsonErr != nil {
-		return jsonErr
-	}
-	time, timeErr := time.Parse("2006-01-02T15:04:05Z", rawString.Val)
-
-	*jt = jsonTime(time)
-	return timeErr
-}
-
-func (jt jsonTime) MarshalJSON() ([]byte, error) {
-	timeString := time.Time(jt).Format("2006-01-02T15:04:05Z")
-	return json.Marshal(struct {
-		Val string `json:"timestampValue"`
-	}{timeString})
-}
-
-// event converts rawEventFields into an Event
-func (jef rawEventFields) event() Event {
-	return Event{string(jef.Name), string(jef.Venue), time.Time(jef.Start), time.Time(jef.End)}
-}
-
-// SORTING AND FILTERING:
 
 // Event represents a booking
-// to add other fields, modify: Event, rawEventFields and rawEventFields.event()
 type Event struct {
 	Name  string
 	Venue string
@@ -134,72 +39,71 @@ type Event struct {
 	End   time.Time
 }
 
+// timeInfo returns the time info of an Event in a readable format with duplicate info minimised
+func (event *Event) timeInfo() string {
+	start := event.Start
+	end := event.End
+	y1, m1, d1 := start.Local().Date()
+	y2, m2, d2 := end.Local().Date()
+
+	if y1 == y2 && m1 == m2 && d1 == d2 {
+		return fmt.Sprintf("%s to %s, %s", FormatTime(start), FormatTime(end), FormatDate(start))
+	}
+	return fmt.Sprintf("%s to %s", FormatTimeDate(start), FormatTimeDate(end))
+}
+
+// toString returns a string with the name and date/time information of an Event, with event name bolded.
+func (event Event) toString() string {
+	return fmt.Sprintf("*%s:* %s", event.Name, event.timeInfo())
+}
+
 // Space represents a list of Events at the same venue
 type Space []Event
-
-// Spaces is a list of spaces
-type Spaces []Space
-
-// byStartDate implements sort.Interface for a Events in a Space based on space[i].Start field
-type byStartDate Space
-
-// used with filter functions
-type eventPredicate func(Event) bool
-
-// getSpaces returns the Events (as Spaces) from firestore which match the query (made using makeQuery)
-func getSpaces(query string) Spaces {
-
-	url := "https://firestore.googleapis.com/v1beta1/projects/usc-website-206715/databases/(default)/documents:runQuery?fields=document" //do not return createTime,updateTime and readTime
-
-	spaces := make(Spaces, 0)
-
-	response, responseErr := http.Post(url, "application/json", strings.NewReader(query))
-	if responseErr != nil {
-		log.Print("Error in spaces.go while receiving HTTP response")
-		return spaces
-	}
-	defer response.Body.Close()
-
-	rawData, rawDataErr := ioutil.ReadAll(response.Body)
-	if rawDataErr != nil {
-		log.Print("Error in spaces.go while reading HTTP response body")
-		return spaces
-	}
-
-	var queryDocs []queryDocument
-	if jsonErr := json.Unmarshal(rawData, &queryDocs); jsonErr != nil {
-		log.Print("error in spaces.go while parsing JSON")
-		return spaces
-	}
-
-	for _, doc := range queryDocs {
-		spaces.addEvent(doc.RawEvent.Fields.event())
-	}
-
-	return spaces
-}
-
-// getSpacesAfter returns the Events (as Spaces) whose endDate is after the specified date
-func getSpacesAfter(date time.Time) Spaces {
-	query := makeQuery("endDate", GreaterThan, jsonTime(date.UTC())) //convert to UTC as firestore stores UTC datetimes
-	return getSpaces(query)
-}
 
 // getName returns the name of the Space (ie. venue). It is assumed all events have been correctly added to the Space.
 // If a Space has no Events, then an empty string is returned.
 func (space Space) getName() string {
 	if len(space) > 0 {
 		return space[0].Venue
+	} else {
+		return ""
 	}
-
-	return ""
-
 }
 
 // addEvent adds an Event to a Space. Does not check whether the event to be added has the same venue as the other events in that Space.
 func (space *Space) addEvent(event Event) {
 	*space = append(*space, event)
 }
+
+// byStartDate implements sort.Interface for a Events in a Space based on space[i].Start field
+type byStartDate Space
+
+func (events byStartDate) Len() int           { return len(events) }
+func (events byStartDate) Swap(i, j int)      { events[i], events[j] = events[j], events[i] }
+func (events byStartDate) Less(i, j int) bool { return events[i].Start.Before(events[j].Start) }
+
+// sortByStartDate returns a new Space sorted in ascending order by Event.Start
+func (space Space) sortByStartDate() Space {
+	sort.Sort(byStartDate(space))
+	return space
+}
+
+// toString returns a string with the name of the space, followed by a list of the Events occuring. Only the name of the space will be printed if the space contains no Events.
+func (space Space) toString() string {
+	sortedSpaces := space.sortByStartDate()
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("=======================\n%s\n=======================\n", space.getName()))
+	for _, event := range sortedSpaces {
+		sb.WriteString(event.toString())
+		sb.WriteString("\n\n")
+	}
+
+	return sb.String()
+}
+
+// Spaces is a list of spaces
+type Spaces []Space
 
 // addEvent adds an Event to the appropriate Space, if it exists. Otherwise, a new Space is created.
 func (spaces *Spaces) addEvent(event Event) {
@@ -217,16 +121,6 @@ func (spaces *Spaces) addEvent(event Event) {
 	*spaces = append(*spaces, space)
 }
 
-func (events byStartDate) Len() int           { return len(events) }
-func (events byStartDate) Swap(i, j int)      { events[i], events[j] = events[j], events[i] }
-func (events byStartDate) Less(i, j int) bool { return events[i].Start.Before(events[j].Start) }
-
-// sortByStartDate returns a new Space sorted in ascending order by Event.Start
-func (space Space) sortByStartDate() Space {
-	sort.Sort(byStartDate(space))
-	return space
-}
-
 func (spaces Spaces) sortByStartDate() Spaces {
 	sortedSpaces := make(Spaces, len(spaces))
 	for i, space := range spaces {
@@ -235,29 +129,89 @@ func (spaces Spaces) sortByStartDate() Spaces {
 	return sortedSpaces
 }
 
-// filter returns a new Space with only Events which satisfy the predicate.
-func (space Space) filter(predicate eventPredicate) Space {
-	filteredEvents := make(Space, 0, len(space))
-	for _, event := range space {
-		if predicate(event) {
-			filteredEvents = append(filteredEvents, event)
-		}
+// toString returns a string with a list of spaces (using Space.toString). If Spaces is empty [No bookings
+func (spaces Spaces) toString() string {
+
+	if len(spaces) == 0 {
+		return "[No bookings recorded]"
 	}
-	return filteredEvents
+
+	var sb strings.Builder
+	for _, space := range spaces {
+		sb.WriteString(space.toString())
+	}
+	return sb.String()
 }
 
-// filter returns a new Spaces with only Events which satisfy the predicate
-func (spaces Spaces) filter(predicate eventPredicate) Spaces {
-	filteredSpaces := make(Spaces, 0, len(spaces))
-	for _, space := range spaces {
-		filteredSpace := space.filter(predicate)
-		//do not add spaces with no events
-		if len(filteredSpace) > 0 {
-			filteredSpaces = append(filteredSpaces, filteredSpace)
-		}
-	}
-	return filteredSpaces
+// Backend:
+
+// Firestore
+
+const uscWebsiteProjectID = "usc-website-206715"
+
+type eventData struct {
+	Name  fs.String `json:"name"`
+	Venue fs.String `json:"venueName"`
+	Start fs.Time   `json:"startDate"`
+	End   fs.Time   `json:"endDate"`
 }
+
+func (e eventData) toEvent() Event {
+	return Event{
+		Name:  e.Name.Value(),
+		Venue: e.Venue.Value(),
+		Start: e.Start.Value(),
+		End:   e.End.Value(),
+	}
+}
+
+// getSpacesAfter returns the Events (as Spaces) whose endDate is after the specified date
+func getSpacesAfter(date time.Time) Spaces {
+	query := fs.Query{
+		From: []fs.CollectionSelector{{CollectionId: "events", AllDescendants: false}},
+		Where: []fs.Filter{{
+			Field:          "endDate",
+			Op:             fs.GreaterThan,
+			FirestoreValue: fs.Time(date),
+		}},
+	}
+
+	parse := func(raw json.RawMessage) (interface{}, error) {
+		data := eventData{}
+		err := json.Unmarshal(raw, &data)
+		return data, err
+	}
+
+	spaces := make(Spaces, 0)
+
+	docs, err := fs.RunQueryAndParse(uscWebsiteProjectID, query, parse, false)
+
+	if err != nil {
+		return spaces
+	}
+
+	for _, doc := range docs {
+		spaces.addEvent(doc.Data.(eventData).toEvent())
+	}
+
+	return spaces
+}
+
+// Filtering
+
+// startOfDay returns a new time.Time with the time set to 00:00 (SG time)
+func startOfDay(date time.Time) time.Time {
+	localDate := date.Local()
+	return time.Date(localDate.Year(), localDate.Month(), localDate.Day(), 0, 0, 0, 0, localDate.Location())
+}
+
+// endOfDay returns the next day 00:00
+func endOfDay(date time.Time) time.Time {
+	return startOfDay(date.AddDate(0, 0, 1))
+}
+
+// used with filter functions
+type eventPredicate func(Event) bool
 
 // eventBetween returns true if an event occurs between the 2 times given. assumes firstDate and lastDate are not equal
 func eventBetween(firstDate, lastDate time.Time) eventPredicate {
@@ -284,83 +238,31 @@ func eventBetweenDays(firstDate, lastDate time.Time) eventPredicate {
 	return eventBetween(startOfDay(firstDate), endOfDay(lastDate))
 }
 
-// startOfDay returns a new time.Time with the time set to 00:00 (SG time)
-func startOfDay(date time.Time) time.Time {
-	localDate := date.Local()
-	return time.Date(localDate.Year(), localDate.Month(), localDate.Day(), 0, 0, 0, 0, localDate.Location())
-}
-
-// endOfDay returns the next day 00:00
-func endOfDay(date time.Time) time.Time {
-	return startOfDay(date.AddDate(0, 0, 1))
-}
-
-// DISPLAYING:
-
-// FormatDate formats a time.Time into date in a standardised format
-func FormatDate(t time.Time) string {
-	return t.Local().Format("Mon 02 Jan 06")
-}
-
-// FormatTime formats a time.Time into a time in a standardised format
-func FormatTime(t time.Time) string {
-	localT := t.Local()
-	if localT.Minute() == 0 {
-		return localT.Format("03PM")
+// filter returns a new Space with only Events which satisfy the predicate.
+func (space Space) filter(predicate eventPredicate) Space {
+	filteredEvents := make(Space, 0, len(space))
+	for _, event := range space {
+		if predicate(event) {
+			filteredEvents = append(filteredEvents, event)
+		}
 	}
-	return localT.Format("03:04PM")
+	return filteredEvents
 }
 
-// FormatTimeDate formats a time.Time into a full time and date, in a standardised format
-func FormatTimeDate(t time.Time) string {
-	return fmt.Sprintf("%s, %s", FormatTime(t), FormatDate(t))
-}
-
-// timeInfo returns the time info of an Event in a readable format with duplicate info minimised
-func (event *Event) timeInfo() string {
-	start := event.Start
-	end := event.End
-	y1, m1, d1 := start.Local().Date()
-	y2, m2, d2 := end.Local().Date()
-
-	if y1 == y2 && m1 == m2 && d1 == d2 {
-		return fmt.Sprintf("%s to %s, %s", FormatTime(start), FormatTime(end), FormatDate(start))
-	}
-	return fmt.Sprintf("%s to %s", FormatTimeDate(start), FormatTimeDate(end))
-}
-
-// toString returns a string with the name and date/time information of an Event, with event name bolded.
-func (event Event) toString() string {
-	return fmt.Sprintf("*%s:* %s", event.Name, event.timeInfo())
-}
-
-// toString returns a string with the name of the space, followed by a list of the Events occuring. Only the name of the space will be printed if the space contains no Events.
-func (space Space) toString() string {
-	sortedSpaces := space.sortByStartDate()
-	var sb strings.Builder
-
-	sb.WriteString(fmt.Sprintf("=======================\n%s\n=======================\n", space.getName()))
-	for _, event := range sortedSpaces {
-		sb.WriteString(event.toString())
-		sb.WriteString("\n\n")
-	}
-
-	return sb.String()
-}
-
-// toString returns a string with a list of spaces (using Space.toString). If Spaces is empty [No bookings recorded] will be returned instead.
-func (spaces Spaces) toString() string {
-
-	if len(spaces) == 0 {
-		return "[No bookings recorded]"
-	}
-
-	var sb strings.Builder
+// filter returns a new Spaces with only Events which satisfy the predicate
+func (spaces Spaces) filter(predicate eventPredicate) Spaces {
+	filteredSpaces := make(Spaces, 0, len(spaces))
 	for _, space := range spaces {
-		sb.WriteString(space.toString())
+		filteredSpace := space.filter(predicate)
+		//do not add spaces with no events
+		if len(filteredSpace) > 0 {
+			filteredSpaces = append(filteredSpaces, filteredSpace)
+		}
 	}
-	return sb.String()
+	return filteredSpaces
 }
+
+// Spaces command:
 
 // bookingsNowMessage returns currently ongoing events
 func bookingsNowMessage() string {
@@ -456,20 +358,6 @@ func ParseDDMMYYDate(date string) (time.Time, error) {
 	return t, err
 }
 
-//Spaces is the primary Cinnabot Spaces method that the end user interacts with.
-//	"/spaces" displays bookings for today.
-//	"/spaces now" displays bookings right this moment.
-//	"/spaces week" displays bookings in the next 7 days.
-//	"/spaces dd/mm/yy" displays bookings on the given date.
-//	"/spaces dd/mm/yy dd/mm/yy" displays bookings in the given interval (limited to one month++).
-//	"/spaces help" informs the user of available commands.
-//
-//	Extra arguments are ignored.
-//	Unparseable commands return the help menu.
-func (cb *Cinnabot) Spaces(msg *message) {
-	cb.SendTextMessage(msg.From.ID, spacesMsg(msg))
-}
-
 // for easier debugging
 func spacesMsg(msg *message) string {
 	toSend := ""
@@ -515,4 +403,18 @@ func spacesMsg(msg *message) string {
 	}
 
 	return toSend
+}
+
+//Spaces is the primary Cinnabot Spaces method that the end user interacts with.
+//	"/spaces" displays bookings for today.
+//	"/spaces now" displays bookings right this moment.
+//	"/spaces week" displays bookings in the next 7 days.
+//	"/spaces dd/mm/yy" displays bookings on the given date.
+//	"/spaces dd/mm/yy dd/mm/yy" displays bookings in the given interval (limited to one month++).
+//	"/spaces help" informs the user of available commands.
+//
+//	Extra arguments are ignored.
+//	Unparseable commands return the help menu.
+func (cb *Cinnabot) Spaces(msg *message) {
+	cb.SendTextMessage(msg.From.ID, spacesMsg(msg))
 }

--- a/utils/time.go
+++ b/utils/time.go
@@ -1,0 +1,10 @@
+package utils
+
+import (
+	t "time"
+)
+
+// SgLocation returns a Location representing Singapore's time zone (UTC+8).
+func SgLocation() *t.Location {
+	return t.FixedZone("+08", 8*60*60)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
- Created firestore package to separate out logic for reading from firestore, which is required for both /spaces and /laundry
- Implemented /laundry command and added it to /help
- Migrated spaces.go to use firestore package
- Made some minor improvements to the time related functions in spaces.go:
  - Explicitly convert times to Sg time, instead of relying on local time, in case server doesn't use Sg time
  - Make sure ParseDDMMYYDate returns date in Sg time
  - Remove unecessary timezone conversions

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fixes #7 (laundry availability)
- Using the firestore package makes spaces.go much more readable

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Unit tests for firestore package
- Manually tested /laundry and /spaces using a test bot - verified that the output of /laundry was consistent with the readings on firestore and that the output for /spaces (for various dates) was consistent with the current cinnabot.

### Screenshots (if appropriate):
/laundry:
![image](https://user-images.githubusercontent.com/43085850/71636255-63c07680-2c68-11ea-8374-bd84bf1ad1c5.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)